### PR TITLE
chore: remove pinned vite and update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,12 @@
       "name": "modkaffes.com",
       "version": "1.0.0",
       "dependencies": {
-        "@tailwindcss/vite": "^4.2.2",
-        "tailwindcss": "^4.2.2",
-        "vite": "^7.3.2"
+        "@tailwindcss/vite": "^4.3.0",
+        "tailwindcss": "^4.3.0"
       },
       "devDependencies": {
         "@astrojs/partytown": "^2.1.7",
-        "astro": "^6.3.1",
+        "astro": "^6.3.7",
         "prettier": "^3.8.3",
         "prettier-plugin-astro": "^0.14.1"
       }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,12 @@
     "format": "prettier -w --plugin-search-dir . '**/*.{js,jsx,md,mdx,cjs,ts,tsx,astro,svelte,vue,html}'"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.2.2",
-    "tailwindcss": "^4.2.2",
-    "vite": "^7.3.2"
+    "@tailwindcss/vite": "^4.3.0",
+    "tailwindcss": "^4.3.0"
   },
   "devDependencies": {
     "@astrojs/partytown": "^2.1.7",
-    "astro": "^6.3.1",
+    "astro": "^6.3.7",
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1"
   }


### PR DESCRIPTION
## Summary

- Remove explicit `vite` pin from dependencies (no longer needed after the pnpm → npm switch)
- Bump `@tailwindcss/vite` and `tailwindcss` `4.2.2 → 4.3.0`
- Bump `astro` `6.3.1 → 6.3.7`

## Test plan

- [ ] `npm run build` completes without errors
- [ ] Site renders correctly